### PR TITLE
update bucket scan to handle cluster metadata

### DIFF
--- a/resources/test/cluster_manifest.json
+++ b/resources/test/cluster_manifest.json
@@ -1,0 +1,1 @@
+{"version":1,"compat_version":1,"upload_time_since_epoch":1668768681875,"cluster_uuid":"19fd9bd7-29e9-4da4-85cf-7199b2997ad3","metadata_id":3,"controller_snapshot_offset":380,"controller_snapshot_path":"cluster_metadata/19fd9bd7-29e9-4da4-85cf-7199b2997ad3/380/controller.snapshot"}

--- a/src/remote_types.rs
+++ b/src/remote_types.rs
@@ -13,6 +13,17 @@ use std::marker::PhantomData;
 use xxhash_rust::xxh32::xxh32;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClusterMetadataManifest {
+    pub version: u32, // This field is explicit in JSON, in serde it is the envelope version
+    pub compat_version: u32, // This field is explicit in JSON, in serde it is the envelope version
+    pub upload_time_since_epoch: i64,
+    pub cluster_uuid: String,
+    pub metadata_id: i64,
+    pub controller_snapshot_offset: i64,
+    pub controller_snapshot_path: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PartitionManifestSegment {
     // Mandatory fields: always set, since v22.1.x
     pub base_offset: RawOffset,
@@ -875,6 +886,10 @@ mod tests {
         read_json(path).await
     }
 
+    async fn read_cluster_manifest(path: &str) -> ClusterMetadataManifest {
+        read_json(path).await
+    }
+
     #[test_log::test(tokio::test)]
     async fn test_manifest_decode() {
         let manifest = read_manifest("/resources/test/manifest.json").await;
@@ -1008,5 +1023,23 @@ mod tests {
 
         let json_manifest = serde_json::to_string(&manifest).unwrap();
         assert_eq!(json_manifest.find("last_uploaded_compacted_offset"), None);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_cluster_manifest_decode() {
+        let manifest = read_cluster_manifest("/resources/test/cluster_manifest.json").await;
+        assert_eq!(manifest.version, 1);
+        assert_eq!(manifest.compat_version, 1);
+        assert_eq!(manifest.upload_time_since_epoch, 1668768681875);
+        assert_eq!(
+            manifest.cluster_uuid,
+            "19fd9bd7-29e9-4da4-85cf-7199b2997ad3"
+        );
+        assert_eq!(manifest.metadata_id, 3);
+        assert_eq!(manifest.controller_snapshot_offset, 380);
+        assert_eq!(
+            manifest.controller_snapshot_path,
+            "cluster_metadata/19fd9bd7-29e9-4da4-85cf-7199b2997ad3/380/controller.snapshot"
+        );
     }
 }


### PR DESCRIPTION
This adds a couple tricks to the bucket scan around cluster metadata, to be used to begin validating the behavior of metadata uploads:
- adds handling for controller snapshots and cluster metadata manifests
- checks that the highest-IDed manifest points at a controller snapshot that exists (if any)